### PR TITLE
Do not fail when `max_workers` is auto-detected

### DIFF
--- a/bounded_pool_executor/__init__.py
+++ b/bounded_pool_executor/__init__.py
@@ -27,12 +27,12 @@ class BoundedProcessPoolExecutor(_BoundedPoolExecutor, concurrent.futures.Proces
 
     def __init__(self, max_workers=None):
         super().__init__(max_workers)
-        self.semaphore = multiprocessing.BoundedSemaphore(max_workers)
+        self.semaphore = multiprocessing.BoundedSemaphore(self._max_workers)
 
 
 class BoundedThreadPoolExecutor(_BoundedPoolExecutor, concurrent.futures.ThreadPoolExecutor):
 
     def __init__(self, max_workers=None):
         super().__init__(max_workers)
-        self.semaphore = threading.BoundedSemaphore(max_workers)
+        self.semaphore = threading.BoundedSemaphore(self._max_workers)
 


### PR DESCRIPTION
When auto-detecting the value of `max_workers` by not passing it, or passing `None`, it is initialized by the `ProcessPoolExecutor`/`ThreadPoolExecutor` constructor.

In the current state of the source code, that `None` value can be passed to the `BoundedSemaphore` constructor. The problem is that it needs an integer value.

The error:

```
Traceback (most recent call last):
  File "/home/cbenz/Dev/test.py", line 261, in run_with_threads
    with BoundedThreadPoolExecutor() as executor:
  File "/home/cbenz/Dev/dbnomics/dbnomics-solr/.venv/lib/python3.10/site-packages/bounded_pool_executor/__init__.py", line 37, in __init__
    self.semaphore = threading.BoundedSemaphore(max_workers)
  File "/usr/lib/python3.10/threading.py", line 504, in __init__
    Semaphore.__init__(self, value)
  File "/usr/lib/python3.10/threading.py", line 416, in __init__
    if value < 0:
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

I propose to re-read the auto-detected value from the current instance.